### PR TITLE
Change the usage text of encrypt option of export

### DIFF
--- a/cmd/sncli/main.go
+++ b/cmd/sncli/main.go
@@ -1000,7 +1000,7 @@ func startCLI(args []string) (msg string, display bool, err error) {
 			Flags: []cli.Flag{
 				cli.BoolTFlag{
 					Name:  "encrypted (default: true)",
-					Usage: "number of tags",
+					Usage: "encrypt the exported data",
 				},
 				cli.StringFlag{
 					Name:   "format",


### PR DESCRIPTION
The usage text was wrong. I changed the text to something that explains the option.