### PR TITLE
fixing archive names for linux/windows, adding universal mac build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ before:
 
 # join mac binaries into one
 universal_binaries:
-  - id: sn-macos-universal
+  - id: sn-macos
     ids:
-      - sn-macos
+      - sn-macos-amd64
       - sn-macos-arm
     name_template: "sn"
     replace: true
@@ -23,7 +23,7 @@ universal_binaries:
       post: |
         sh -c '
         cat > /tmp/sn-cli-gon-universal.hcl << EOF
-        source = ["./dist/sn-macos_darwin_universal/sn"]
+        source = ["./dist/sn-macos_darwin_all/sn"]
         bundle_id = "uk.co.lessknown.sn-cli"
         apple_id {
           username = "jon@lessknown.co.uk"
@@ -33,14 +33,14 @@ universal_binaries:
           application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
         }
         zip {
-          output_path = "./dist/sn-cli_Darwin_universal.zip"
+          output_path = "./dist/sn-cli_Darwin_all.zip"
         }
         EOF
         gon /tmp/sn-cli-gon-universal.hcl
         '
 
 builds:
-  - id: sn-macos
+  - id: sn-macos-amd64
     main: ./cmd/sncli/
     binary: sn
     goos:
@@ -124,4 +124,6 @@ changelog:
     - ignore
 
 checksum:
+  extra_files:
+    - glob: ./dist/sn-cli_Darwin*.zip
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,35 @@ before:
     - make clean
     - go mod tidy
 
+# join mac binaries into one
+universal_binaries:
+  - id: sn-macos-universal
+    ids:
+      - sn-macos
+      - sn-macos-arm
+    name_template: "sn"
+    replace: true
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    hooks:
+      post: |
+        sh -c '
+        cat > /tmp/sn-cli-gon-universal.hcl << EOF
+        source = ["./dist/sn-macos_darwin_universal/sn"]
+        bundle_id = "uk.co.lessknown.sn-cli"
+        apple_id {
+          username = "jon@lessknown.co.uk"
+          password = "@env:AC_PASSWORD"
+        }
+        sign {
+          application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
+        }
+        zip {
+          output_path = "./dist/sn-cli_Darwin_universal.zip"
+        }
+        EOF
+        gon /tmp/sn-cli-gon-universal.hcl
+        '
+
 builds:
   - id: sn-macos
     main: ./cmd/sncli/
@@ -22,25 +51,6 @@ builds:
       - -trimpath
     ldflags:
       - "-s -w -X main.version={{ .Version }} -X main.sha={{ .ShortCommit }} -X main.buildDate={{ .Date }} -X main.tag={{ .Tag }}"
-    hooks:
-      post: |
-        sh -c '
-        cat > /tmp/sn-cli-gon-amd64.hcl << EOF
-        source = ["./dist/sn-macos_darwin_amd64_v1/sn"]
-        bundle_id = "uk.co.lessknown.sn-cli"
-        apple_id {
-          username = "jon@lessknown.co.uk"
-          password = "@env:AC_PASSWORD"
-        }
-        sign {
-          application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
-        }
-        zip {
-          output_path = "./dist/sn-cli_Darwin_amd64.zip"
-        }
-        EOF
-        gon /tmp/sn-cli-gon-amd64.hcl
-        '
 
   - id: sn-macos-arm
     main: ./cmd/sncli/
@@ -53,25 +63,7 @@ builds:
       - -trimpath
     ldflags:
       - "-s -w -X main.version={{ .Version }} -X main.sha={{ .ShortCommit }} -X main.buildDate={{ .Date }} -X main.tag={{ .Tag }}"
-    hooks:
-      post: |
-        sh -c '
-        cat > /tmp/sn-cli-gon-arm64.hcl << EOF
-        source = ["./dist/sn-macos-arm_darwin_arm64/sn"]
-        bundle_id = "uk.co.lessknown.sn-cli"
-        apple_id {
-          username = "jon@lessknown.co.uk"
-          password = "@env:AC_PASSWORD"
-        }
-        sign {
-          application_identity = "Developer ID Application: Jonathan Hadfield (VBZY8FBYR5)"
-        }
-        zip {
-          output_path = "./dist/sn-cli_Darwin_arm64.zip"
-        }
-        EOF
-        gon /tmp/sn-cli-gon-arm64.hcl
-        '
+
   - id: sn
     main: ./cmd/sncli/
     binary: sn
@@ -94,15 +86,11 @@ archives:
       {{ .ProjectName }}_
       {{- if eq .Os "linux" }}Linux_
       {{- else if eq .Os "windows" }}Windows_
-      {{- else }}{{- tolower .Os }}_{{ end }}
+      {{- else }}{{- tolower .Os }}_{{ end -}}
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{ if .Arm }}v{{ .Arm }}{{ end }}
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+      {{- else }}{{ .Arch }}{{ end -}}
+      {{ if .Arm }}v{{ .Arm }}{{ end -}}
     builds:
       - sn
     format: tar.gz

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## changelog
+0.2.7 - fix archive names, combine MacOS builds into universal binary
 0.0.13 - enable storing of session in MacOS and Linux with optional encryption  
 0.0.12 - fix Register bug on Windows  
 0.0.11 - fix ReadPassword bug on Windows  


### PR DESCRIPTION
I looked at the assets page and saw some confusing names for the linux and windows builds:
```
 sn-cli_Linux_arm64.linux.Linux.windows.Windows.386.i386.amd64.x86_64.tar.gz
3.76 MB 2023-08-27T12:25:51Z
sn-cli_Linux_x86_64.linux.Linux.windows.Windows.386.i386.amd64.x86_64.tar.gz
4.11 MB 2023-08-27T12:25:50Z
sn-cli_Windows_arm64.linux.Linux.windows.Windows.386.i386.amd64.x86_64.zip
3.72 MB 2023-08-27T12:25:51Z
sn-cli_Windows_x86_64.linux.Linux.windows.Windows.386.i386.amd64.x86_64.zip 
```
I think there was a typo in the `.goreleaser.yaml`, i removed that and add some whitespace trimming to the templating.
I also added a [macos universal build](https://goreleaser.com/customization/universalbinaries/) and added that zip to the checksum file. I don't have an apple developer profile so i just tested with `zip  ./dist/sn-cli_Darwin_all.zip ./dist/sn-macos_darwin_all/sn` as my post hook, but I think that would work if you wanted to test it for yourself.


My dist folder looked like: 
```
$ ls -1 dist
artifacts.json
checksums.txt
config.yaml
metadata.json
sn-cli_Darwin_all.zip
sn-cli_Linux_arm64.tar.gz
sn-cli_Linux_x86_64.tar.gz
sn-cli_Windows_arm64.zip
sn-cli_Windows_x86_64.zip
sn-macos-amd64_darwin_amd64_v1
sn-macos-arm_darwin_arm64
sn-macos_darwin_all
sn_linux_amd64_v1
sn_linux_arm64
sn_windows_amd64_v1
sn_windows_arm64
```

Thanks for this tool, it was exactly what I was looking for! 