### PR TITLE
Add the ability to create nested Tags via parents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage.txt
 
 # local build
 .local_dist
+bin/*
+!bin/.gitkeep
+
 # github release build
 dist
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ clean:
 	rm -rf ./dist
 
 setup:
-	go get -u github.com/alecthomas/gometalinter
-	go get -u golang.org/x/tools/cmd/cover
-	gometalinter --install --update
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+	go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
 
 test:
 	echo 'mode: atomic' > coverage.txt && go list ./... | xargs -n1 -I{} sh -c 'go test -v -failfast -p 1 -parallel 1 -timeout=600s -covermode=atomic -coverprofile=coverage.tmp {} && tail -n +2 coverage.tmp >> coverage.txt' && rm coverage.tmp

--- a/cmd/sncli/main.go
+++ b/cmd/sncli/main.go
@@ -263,12 +263,20 @@ func startCLI(args []string) (msg string, useStdOut bool, err error) {
 						if c.NArg() > 0 {
 							return
 						}
-						fmt.Println("--title")
+						fmt.Println("--title", "--parent", "--parent-uuid")
 					},
 					Flags: []cli.Flag{
 						cli.StringFlag{
 							Name:  "title",
 							Usage: "new tag title (separate multiple with commas)",
+						},
+						cli.StringFlag{
+							Name:  "parent",
+							Usage: "parent tag title to make a sub-tag of",
+						},
+						cli.StringFlag{
+							Name:  "parent-uuid",
+							Usage: "parent tag uuid to make a sub-tag of",
 						},
 					},
 					Action: func(c *cli.Context) error {

--- a/cmd/sncli/tag.go
+++ b/cmd/sncli/tag.go
@@ -384,10 +384,6 @@ func processAddTags(c *cli.Context, opts configOptsOutput) (msg string, err erro
 		return "", errors.New("tag title not defined")
 	}
 
-	// getParent := gosn.ItemFilters{
-	// 	MatchAny: true,
-	// }
-
 	// get session
 	session, _, err := cache.GetSession(opts.useSession, opts.sessKey, opts.server, opts.debug)
 	if err != nil {

--- a/cmd/sncli/tag.go
+++ b/cmd/sncli/tag.go
@@ -206,7 +206,7 @@ func processGetTags(c *cli.Context, opts configOptsOutput) (msg string, err erro
 	inTitle := strings.TrimSpace(c.String("title"))
 	inUUID := strings.TrimSpace(c.String("uuid"))
 
-	var matchAny bool
+	matchAny := true
 	if c.Bool("match-all") {
 		matchAny = false
 	}

--- a/cmd/sncli/tag.go
+++ b/cmd/sncli/tag.go
@@ -377,11 +377,16 @@ func processGetTags(c *cli.Context, opts configOptsOutput) (msg string, err erro
 func processAddTags(c *cli.Context, opts configOptsOutput) (msg string, err error) {
 	// validate input
 	tagInput := c.String("title")
+	// parentTitle := c.String("parent")
 	if strings.TrimSpace(tagInput) == "" {
 		_ = cli.ShowSubcommandHelp(c)
 
 		return "", errors.New("tag title not defined")
 	}
+
+	// getParent := gosn.ItemFilters{
+	// 	MatchAny: true,
+	// }
 
 	// get session
 	session, _, err := cache.GetSession(opts.useSession, opts.sessKey, opts.server, opts.debug)

--- a/cmd/sncli/tag.go
+++ b/cmd/sncli/tag.go
@@ -397,9 +397,11 @@ func processAddTags(c *cli.Context, opts configOptsOutput) (msg string, err erro
 	// prepare input
 	tags := sncli.CommaSplit(tagInput)
 	addTagInput := sncli.AddTagsInput{
-		Session: &session,
-		Tags:    tags,
-		Debug:   opts.debug,
+		Session:    &session,
+		Tags:       tags,
+		Parent:     c.String("parent"),
+		ParentUUID: c.String("parent-uuid"),
+		Debug:      opts.debug,
 	}
 
 	// attempt to add tags

--- a/cmd/sncli/tag.go
+++ b/cmd/sncli/tag.go
@@ -377,7 +377,6 @@ func processGetTags(c *cli.Context, opts configOptsOutput) (msg string, err erro
 func processAddTags(c *cli.Context, opts configOptsOutput) (msg string, err error) {
 	// validate input
 	tagInput := c.String("title")
-	// parentTitle := c.String("parent")
 	if strings.TrimSpace(tagInput) == "" {
 		_ = cli.ShowSubcommandHelp(c)
 

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,5 @@ require (
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 )
 
-//replace github.com/jonhadfield/gosn-v2 => ../gosn-v2
+//TODO: comment out before release
+replace github.com/jonhadfield/gosn-v2 => ../gosn

--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,4 @@ require (
 )
 
 // replace github.com/jonhadfield/gosn-v2 => ../gosn-v2
+replace github.com/jonhadfield/gosn-v2 => github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163

--- a/go.mod
+++ b/go.mod
@@ -60,5 +60,4 @@ require (
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 )
 
-//TODO: comment out before release
-replace github.com/jonhadfield/gosn-v2 => ../gosn
+// replace github.com/jonhadfield/gosn-v2 => ../gosn-v2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
-	github.com/jonhadfield/gosn-v2 v0.0.0-20231211223627-abb88b737146
+	github.com/jonhadfield/gosn-v2 v0.0.0-20231212210044-96a40e9cc8cc
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/spf13/viper v1.18.1
 	github.com/stretchr/testify v1.8.4
@@ -60,5 +60,4 @@ require (
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
 )
 
-// replace github.com/jonhadfield/gosn-v2 => ../gosn-v2
-replace github.com/jonhadfield/gosn-v2 => github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163
+//replace github.com/jonhadfield/gosn-v2 => ../gosn-v2

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
-github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163 h1:fdxT7pcOe1n9xZ+4P+XJ41Ko4UhLvO/g/UwO/Iz71vg=
-github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163/go.mod h1:4/EdV1iRAKpaa4ZcF1TuniwRaajeWIMyMEWkrVnq/k8=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -54,6 +52,8 @@ github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT
 github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/jonhadfield/gosn-v2 v0.0.0-20231212210044-96a40e9cc8cc h1:f3RUJ+JRyS1q6Hpm1e36xC3grCec0KRBvC2fuk0+pvo=
+github.com/jonhadfield/gosn-v2 v0.0.0-20231212210044-96a40e9cc8cc/go.mod h1:4/EdV1iRAKpaa4ZcF1TuniwRaajeWIMyMEWkrVnq/k8=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
+github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163 h1:fdxT7pcOe1n9xZ+4P+XJ41Ko4UhLvO/g/UwO/Iz71vg=
+github.com/clayrosenthal/gosn-v2 v0.0.0-20231212073032-3d59f6965163/go.mod h1:4/EdV1iRAKpaa4ZcF1TuniwRaajeWIMyMEWkrVnq/k8=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -52,8 +54,6 @@ github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT
 github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/jonhadfield/gosn-v2 v0.0.0-20231211223627-abb88b737146 h1:JPl0PwwOe06qDLz3g98RimTAYbJ0Wq7SYNLgtxdiH5Q=
-github.com/jonhadfield/gosn-v2 v0.0.0-20231211223627-abb88b737146/go.mod h1:4/EdV1iRAKpaa4ZcF1TuniwRaajeWIMyMEWkrVnq/k8=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/helpers.go
+++ b/helpers.go
@@ -153,8 +153,9 @@ func ItemRefsToYaml(irs []items.ItemReference) []ItemReferenceYAML {
 
 	for _, ref := range irs {
 		iRef := ItemReferenceYAML{
-			UUID:        ref.UUID,
-			ContentType: ref.ContentType,
+			UUID:          ref.UUID,
+			ContentType:   ref.ContentType,
+			ReferenceType: ref.ReferenceType,
 		}
 		iRefs = append(iRefs, iRef)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -132,7 +131,7 @@ type EncryptedItemsFile struct {
 }
 
 func readJSON(filePath string) (items items.EncryptedItems, err error) {
-	file, err := ioutil.ReadFile(filePath)
+	file, err := os.ReadFile(filePath)
 	if err != nil {
 		err = fmt.Errorf("%w failed to open: %s", err, filePath)
 		return
@@ -168,8 +167,9 @@ func ItemRefsToJSON(irs []items.ItemReference) []ItemReferenceJSON {
 
 	for _, ref := range irs {
 		iRef := ItemReferenceJSON{
-			UUID:        ref.UUID,
-			ContentType: ref.ContentType,
+			UUID:          ref.UUID,
+			ContentType:   ref.ContentType,
+			ReferenceType: ref.ReferenceType,
 		}
 		iRefs = append(iRefs, iRef)
 	}

--- a/main.go
+++ b/main.go
@@ -23,8 +23,9 @@ type ItemReferenceYAML struct {
 }
 
 type ItemReferenceJSON struct {
-	UUID        string `json:"uuid"`
-	ContentType string `json:"content_type"`
+	UUID          string `json:"uuid"`
+	ContentType   string `json:"content_type"`
+	ReferenceType string `json:"reference_type",omitempty`
 }
 
 type OrgStandardNotesSNDetailJSON struct {

--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ const (
 )
 
 type ItemReferenceYAML struct {
-	UUID        string `yaml:"uuid"`
-	ContentType string `yaml:"content_type"`
+	UUID          string `yaml:"uuid"`
+	ContentType   string `yaml:"content_type"`
+	ReferenceType string `yaml:"reference_type",omitempty`
 }
 
 type ItemReferenceJSON struct {

--- a/main.go
+++ b/main.go
@@ -151,10 +151,12 @@ type TagItemsConfig struct {
 }
 
 type AddTagsInput struct {
-	Session *cache.Session
-	Tags    []string
-	Debug   bool
-	Replace bool
+	Session    *cache.Session
+	Tags       []string
+	Parent     string
+	ParentUUID string
+	Debug      bool
+	Replace    bool
 }
 
 type AddTagsOutput struct {

--- a/tag.go
+++ b/tag.go
@@ -416,8 +416,9 @@ func addTags(ati addTagsInput) (ato addTagsOutput, err error) {
 			allTags = append(allTags, *tag)
 			if tag.Content.GetTitle() == ati.parent || tag.GetUUID() == ati.parentUUID {
 				itemRef := gosn.ItemReference{
-					UUID:        tag.GetUUID(),
-					ContentType: "Tag",
+					UUID:          tag.GetUUID(),
+					ContentType:   "Tag",
+					ReferenceType: "TagToParentTag",
 				}
 				parentRef = gosn.ItemReferences{itemRef}
 			}

--- a/tag.go
+++ b/tag.go
@@ -418,12 +418,12 @@ func addTags(ati addTagsInput) (ato addTagsOutput, err error) {
 				if parentRef != nil {
 					return ato, errors.New("multiple parent tags found, specify by UUID")
 				}
-				itemRef := gosn.ItemReference{
+				itemRef := items.ItemReference{
 					UUID:          tag.GetUUID(),
 					ContentType:   "Tag",
 					ReferenceType: "TagToParentTag",
 				}
-				parentRef = gosn.ItemReferences{itemRef}
+				parentRef = items.ItemReferences{itemRef}
 			}
 		}
 	}

--- a/tag.go
+++ b/tag.go
@@ -415,6 +415,9 @@ func addTags(ati addTagsInput) (ato addTagsOutput, err error) {
 			tag := item.(*items.Tag)
 			allTags = append(allTags, *tag)
 			if tag.Content.GetTitle() == ati.parent || tag.GetUUID() == ati.parentUUID {
+				if parentRef != nil {
+					return ato, errors.New("multiple parent tags found, specify by UUID")
+				}
 				itemRef := gosn.ItemReference{
 					UUID:          tag.GetUUID(),
 					ContentType:   "Tag",

--- a/tag.go
+++ b/tag.go
@@ -1,6 +1,7 @@
 package sncli
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/jonhadfield/gosn-v2/cache"
@@ -181,9 +182,11 @@ func (i *AddTagsInput) Run() (output AddTagsOutput, err error) {
 	}()
 
 	ati := addTagsInput{
-		tagTitles: i.Tags,
-		session:   i.Session,
-		replace:   i.Replace,
+		tagTitles:  i.Tags,
+		parent:     i.Parent,
+		parentUUID: i.ParentUUID,
+		session:    i.Session,
+		replace:    i.Replace,
 	}
 
 	var ato addTagsOutput
@@ -419,6 +422,14 @@ func addTags(ati addTagsInput) (ato addTagsOutput, err error) {
 				parentRef = gosn.ItemReferences{itemRef}
 			}
 		}
+	}
+
+	if ati.parent != "" && len(parentRef) == 0 {
+		return ato, errors.New("parent tag not found by title")
+	}
+
+	if ati.parentUUID != "" && len(parentRef) == 0 {
+		return ato, errors.New("parent tag not found by UUID")
 	}
 
 	var tagsToAdd items.Tags

--- a/tag_test.go
+++ b/tag_test.go
@@ -33,6 +33,41 @@ func TestAddDeleteTagByTitle(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAddTagWithParent(t *testing.T) {
+	testDelay()
+
+	addTagConfigParent := AddTagsInput{
+		Session: testSession,
+		Tags:    []string{"TestTagParent"},
+	}
+
+	ato, err := addTagConfigParent.Run()
+	require.NoError(t, err)
+	require.Contains(t, ato.Added, "TestTagParent")
+	require.Empty(t, ato.Existing)
+
+	addTagConfigChild := AddTagsInput{
+		Session: testSession,
+		Tags:    []string{"TestTagChild"},
+		Parent:  "TestTagParent",
+	}
+
+	ato, err := addTagConfigChild.Run()
+	require.NoError(t, err)
+	require.Contains(t, ato.Added, "TestTagChild")
+	require.Empty(t, ato.Existing)
+
+	deleteTagConfig := DeleteTagConfig{
+		Session:   testSession,
+		TagTitles: []string{"TestTagParent", "TestTagChild"},
+	}
+
+	var noDeleted int
+	noDeleted, err = deleteTagConfig.Run()
+	require.Equal(t, 2, noDeleted)
+	require.NoError(t, err)
+}
+
 func TestGetTag(t *testing.T) {
 	testDelay()
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -52,7 +52,7 @@ func TestAddTagWithParent(t *testing.T) {
 		Parent:  "TestTagParent",
 	}
 
-	ato, err := addTagConfigChild.Run()
+	ato, err = addTagConfigChild.Run()
 	require.NoError(t, err)
 	require.Contains(t, ato.Added, "TestTagChild")
 	require.Empty(t, ato.Existing)


### PR DESCRIPTION
Adds the ability to specify a `parent` or `parent-uuid` when creating a tag, which then creates a nested tag underneath the specified parent tag.

ex:
```
sn add tag --title nested --parent root
```

which then shows:
```
sn get tag --title 'root,nested'
{
  "tags": [
    {
        "uuid": "62909229-17ec-4d01-ad6d-bec554ca73e8",
        "content": {
            "title": "nested",
            "references": [
                {
                    "uuid": "811a20f3-a130-41f8-9fdc-599c08379efe",
                    "content_type": "Tag",
                    "reference_type": "TagToParentTag"
                }
            ],
            "appData": {
                "org.standardnotes.sn": {
                    "client_updated_at": "2023-12-11T05:58:28.727Z",
                    "prefersPlainEditor": false,
                    "pinned": false
                }
            }
        },
        "content_type": "Tag",
        "created_at": "2023-12-11T05:58:28.727Z",
        "updated_at": "2023-12-11T05:58:29.265Z"
    },
    {
        "uuid": "811a20f3-a130-41f8-9fdc-599c08379efe",
        "content": {
            "title": "root",
            "references": null,
            "appData": {
                "org.standardnotes.sn": {
                    "client_updated_at": "2023-12-11T05:58:15.720Z",
                    "prefersPlainEditor": false,
                    "pinned": false
                }
            }
        },
        "content_type": "Tag",
        "created_at": "2023-12-11T05:58:15.720Z",
        "updated_at": "2023-12-11T05:58:16.387Z"
    }
]
}
```

Needs to be merged after [related gosn PR](https://github.com/jonhadfield/gosn-v2/pull/9)