### PR TITLE
Fix conflict warning and add helper tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ a command-line interface for [Standard Notes](https://standardnotes.org/).
 
 ## latest updates
 
+### version 0.3.5 - 2024-01-08
+
+- fix conflict warning handling
+- add helper tests
+- minor code simplification
+
+
 ### version 0.3.4 - 2024-01-07
 
 - fix command completion and update instructions

--- a/tasks.go
+++ b/tasks.go
@@ -309,9 +309,9 @@ func getAdvancedChecklists(sess *cache.Session, cacheItems cache.Items) (items.A
 	return checklists, nil
 }
 
-func taskListsConflictedWarning([]items.Tasklist) string {
-	if len(items.Tasklists{}) > 0 {
-		return color.Yellow.Sprintf("%d conflicted versions", len(items.Tasklists{}))
+func taskListsConflictedWarning(tasklists []items.Tasklist) string {
+	if len(tasklists) > 0 {
+		return color.Yellow.Sprintf("%d conflicted versions", len(tasklists))
 	}
 
 	return "-"

--- a/tasks_small_test.go
+++ b/tasks_small_test.go
@@ -1,0 +1,51 @@
+package sncli
+
+import (
+	"testing"
+
+	"github.com/jonhadfield/gosn-v2/items"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolToText(t *testing.T) {
+	require.Equal(t, "yes", boolToText(true, "yes", "no"))
+	require.Equal(t, "no", boolToText(false, "yes", "no"))
+}
+
+func TestOutputChars(t *testing.T) {
+	require.Equal(t, "hello", outputChars("hello", 10))
+	long := "abcdefghijklmnop"
+	require.Equal(t, "abcdefghij...", outputChars(long, 10))
+}
+
+func TestTaskListsConflictedWarning(t *testing.T) {
+	tasks := []items.Tasklist{{}, {}}
+	require.Contains(t, taskListsConflictedWarning(tasks), "2 conflicted versions")
+	require.Equal(t, "-", taskListsConflictedWarning(nil))
+}
+
+func TestFilterTasks(t *testing.T) {
+	tasks := items.Tasks{
+		{Title: "done", Completed: true},
+		{Title: "todo", Completed: false},
+	}
+	completed := filterTasks(tasks, true)
+	require.Len(t, completed, 1)
+	require.Equal(t, "done", completed[0].Title)
+	incomplete := filterTasks(tasks, false)
+	require.Len(t, incomplete, 1)
+	require.Equal(t, "todo", incomplete[0].Title)
+}
+
+func TestFilterAdvancedChecklistTasks(t *testing.T) {
+	tasks := items.AdvancedChecklistTasks{
+		{Description: "d1", Completed: true},
+		{Description: "d2", Completed: false},
+	}
+	completed := filterAdvancedChecklistTasks(tasks, true)
+	require.Len(t, completed, 1)
+	require.Equal(t, "d1", completed[0].Description)
+	incomplete := filterAdvancedChecklistTasks(tasks, false)
+	require.Len(t, incomplete, 1)
+	require.Equal(t, "d2", incomplete[0].Description)
+}


### PR DESCRIPTION
## Summary
- fix incorrect use of task conflict warning
- add helper tests for tasks
- document latest updates in README

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*