### PR TITLE
Allow the SonarQube scan to be run manually

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+  # Allows re-running the scan without pushing a commit, e.g. after
+  # rotating SONAR_TOKEN.
+  workflow_dispatch:
 name: sonarqube
 jobs:
   sonarcloud:


### PR DESCRIPTION
The `sonarqube` workflow only triggered `on: push`, so re-testing it after rotating `SONAR_TOKEN` required either pushing a commit or re-running an earlier run. Adding `workflow_dispatch` allows starting it from the Actions tab or with:

```bash
gh workflow run sonarqube.yml
```

Workflow-only change; no application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKSZwABnkoJTMcpUhFife3
