### PR TITLE
Fix unrestorable encrypted backups and clear SonarCloud vulnerabilities

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -12,8 +12,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      # Coverage has to exist before the scan runs, or SonarCloud reports 0%.
+      # Live-server tests stay opt-in, so this is the unit-test coverage only.
+      - name: Run tests
+        run: go test -coverprofile=cover.out -covermode=atomic ./...
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Run tests
         run: go test -coverprofile=cover.out -covermode=atomic ./...
       - name: SonarCloud Scan
+        # nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key
+        # The hex string is this action's pinned commit SHA, not a key. Pinning
+        # is what SonarCloud's githubactions:S7637 asks for.
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           SN_PASSWORD: ${{ secrets.SN_PASSWORD }}
       -
         name: Codacy Coverage Reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           coverage-reports: cover.out
           force-coverage-parser: go

--- a/cmd/sncli/backup.go
+++ b/cmd/sncli/backup.go
@@ -180,7 +180,7 @@ func runBackupRestore(c *cli.Context, opts configOptsOutput) error {
 	}
 
 	// Get backup info first
-	manifest, err := sncli.GetBackupInfo(c.String("input"), "")
+	manifest, err := sncli.GetBackupInfo(c.String("input"))
 	if err != nil {
 		return fmt.Errorf("failed to read backup info: %w", err)
 	}
@@ -270,7 +270,7 @@ func runBackupRestore(c *cli.Context, opts configOptsOutput) error {
 func runBackupInfo(c *cli.Context) error {
 	filename := c.String("file")
 
-	manifest, err := sncli.GetBackupInfo(filename, "")
+	manifest, err := sncli.GetBackupInfo(filename)
 	if err != nil {
 		return err
 	}

--- a/internal/sncli/backup.go
+++ b/internal/sncli/backup.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +17,20 @@ import (
 	"github.com/jonhadfield/gosn-v2/common"
 	"github.com/jonhadfield/gosn-v2/items"
 	"golang.org/x/crypto/pbkdf2"
+)
+
+const (
+	// backupFormatVersion is written into the manifest. Version 1.0 sealed the
+	// manifest itself, which made encrypted backups impossible to restore, and
+	// derived the key from a salt shared by every backup.
+	backupFormatVersion = "2.0"
+
+	// backupKDFIterations follows the OWASP guidance for PBKDF2-HMAC-SHA256.
+	backupKDFIterations = 600000
+
+	backupKDFName  = "pbkdf2-hmac-sha256"
+	backupSaltSize = 32
+	backupKeySize  = 32
 )
 
 // BackupConfig holds backup configuration
@@ -45,6 +60,44 @@ type BackupManifest struct {
 	Incremental bool           `json:"incremental"`
 	Encrypted   bool           `json:"encrypted"`
 	Version     string         `json:"version"`
+
+	// Key-derivation parameters, present only on encrypted backups. These are
+	// not secret: the salt exists to stop one precomputed table from attacking
+	// every backup, so it is stored alongside the ciphertext.
+	KDF        string `json:"kdf,omitempty"`
+	Salt       string `json:"salt,omitempty"`
+	Iterations int    `json:"iterations,omitempty"`
+}
+
+// deriveBackupKey derives the AES key for a backup from its password and the
+// key-derivation parameters recorded in its manifest.
+func deriveBackupKey(password string, salt []byte, iterations int) []byte {
+	return pbkdf2.Key([]byte(password), salt, iterations, backupKeySize, sha256.New)
+}
+
+// newBackupSalt returns a fresh random salt for a single backup.
+func newBackupSalt() ([]byte, error) {
+	salt := make([]byte, backupSaltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, fmt.Errorf("failed to generate salt: %w", err)
+	}
+
+	return salt, nil
+}
+
+// newGCM builds the AEAD used to seal and open backup members.
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	return gcm, nil
 }
 
 // BackupItem represents an item in the backup
@@ -67,6 +120,7 @@ func (b *BackupConfig) Run() error {
 
 	var writer io.Writer = zipFile
 	var gcm cipher.AEAD
+	var salt []byte
 
 	// Set up encryption if requested
 	if b.Encrypt {
@@ -74,18 +128,15 @@ func (b *BackupConfig) Run() error {
 			return fmt.Errorf("password required for encrypted backup")
 		}
 
-		// Derive key from password
-		key := pbkdf2.Key([]byte(b.Password), []byte("sn-cli-backup-salt"), 100000, 32, sha256.New)
-
-		// Create AES cipher
-		block, err := aes.NewCipher(key)
+		// A fresh salt per backup, so one precomputed table cannot attack them all.
+		salt, err = newBackupSalt()
 		if err != nil {
-			return fmt.Errorf("failed to create cipher: %w", err)
+			return err
 		}
 
-		gcm, err = cipher.NewGCM(block)
+		gcm, err = newGCM(deriveBackupKey(b.Password, salt, backupKDFIterations))
 		if err != nil {
-			return fmt.Errorf("failed to create GCM: %w", err)
+			return err
 		}
 	}
 
@@ -98,7 +149,13 @@ func (b *BackupConfig) Run() error {
 		ItemCounts:  make(map[string]int),
 		Incremental: b.Incremental,
 		Encrypted:   b.Encrypt,
-		Version:     "1.0",
+		Version:     backupFormatVersion,
+	}
+
+	if b.Encrypt {
+		manifest.KDF = backupKDFName
+		manifest.Salt = base64.StdEncoding.EncodeToString(salt)
+		manifest.Iterations = backupKDFIterations
 	}
 
 	// Backup notes
@@ -117,7 +174,9 @@ func (b *BackupConfig) Run() error {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
 
-	if err := b.writeZipFile(zipWriter, "manifest.json", manifestData, gcm); err != nil {
+	// The manifest stays in the clear: it carries the parameters needed to
+	// derive the key, so it has to be readable before the key exists.
+	if err := b.writeZipFile(zipWriter, "manifest.json", manifestData, nil); err != nil {
 		return fmt.Errorf("failed to write manifest: %w", err)
 	}
 
@@ -288,15 +347,21 @@ func (r *RestoreConfig) Run() (RestoreResult, error) {
 	}
 	defer zipReader.Close()
 
-	// Read manifest
-	manifestData, encrypted, err := r.readZipFile(&zipReader.Reader, "manifest.json")
+	// Read manifest. It is always stored in the clear.
+	manifestData, err := r.readZipFile(&zipReader.Reader, "manifest.json")
 	if err != nil {
 		return result, fmt.Errorf("failed to read manifest: %w", err)
 	}
 
 	var manifest BackupManifest
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return result, fmt.Errorf("failed to parse manifest: %w", err)
+		// Version 1.0 sealed the manifest too, so it never parsed here and the
+		// backup could not be restored at all. Say so rather than reporting a
+		// stray byte from the ciphertext.
+		return result, fmt.Errorf(
+			"failed to parse manifest: %w (if this is an encrypted backup written by "+
+				"sn-cli 0.4.3 or earlier, it was produced by a version that could not "+
+				"restore its own output)", err)
 	}
 
 	result.Manifest = manifest
@@ -306,25 +371,28 @@ func (r *RestoreConfig) Run() (RestoreResult, error) {
 		return result, fmt.Errorf("password required for encrypted backup")
 	}
 
+	encrypted := manifest.Encrypted
+
 	var gcm cipher.AEAD
 	if manifest.Encrypted {
-		// Derive key from password
-		key := pbkdf2.Key([]byte(r.Password), []byte("sn-cli-backup-salt"), 100000, 32, sha256.New)
-
-		// Create AES cipher
-		block, err := aes.NewCipher(key)
-		if err != nil {
-			return result, fmt.Errorf("failed to create cipher: %w", err)
+		salt, decErr := base64.StdEncoding.DecodeString(manifest.Salt)
+		if decErr != nil || len(salt) == 0 {
+			return result, fmt.Errorf("backup manifest has no usable key-derivation salt")
 		}
 
-		gcm, err = cipher.NewGCM(block)
+		iterations := manifest.Iterations
+		if iterations <= 0 {
+			return result, fmt.Errorf("backup manifest has no usable iteration count")
+		}
+
+		gcm, err = newGCM(deriveBackupKey(r.Password, salt, iterations))
 		if err != nil {
-			return result, fmt.Errorf("failed to create GCM: %w", err)
+			return result, err
 		}
 	}
 
 	// Read notes
-	notesData, _, err := r.readZipFile(&zipReader.Reader, "notes.json")
+	notesData, err := r.readZipFile(&zipReader.Reader, "notes.json")
 	if err != nil {
 		return result, fmt.Errorf("failed to read notes: %w", err)
 	}
@@ -345,7 +413,7 @@ func (r *RestoreConfig) Run() (RestoreResult, error) {
 	result.NotesCount = len(notes)
 
 	// Read tags
-	tagsData, _, err := r.readZipFile(&zipReader.Reader, "tags.json")
+	tagsData, err := r.readZipFile(&zipReader.Reader, "tags.json")
 	if err != nil {
 		return result, fmt.Errorf("failed to read tags: %w", err)
 	}
@@ -371,28 +439,27 @@ func (r *RestoreConfig) Run() (RestoreResult, error) {
 	return result, nil
 }
 
-// readZipFile reads a file from the zip archive
-func (r *RestoreConfig) readZipFile(zipReader *zip.Reader, filename string) ([]byte, bool, error) {
+// readZipFile reads a member of the archive verbatim. Whether it is encrypted
+// is recorded in the manifest, not guessed from its length.
+func (r *RestoreConfig) readZipFile(zipReader *zip.Reader, filename string) ([]byte, error) {
 	for _, file := range zipReader.File {
 		if file.Name == filename {
 			rc, err := file.Open()
 			if err != nil {
-				return nil, false, err
+				return nil, err
 			}
 			defer rc.Close()
 
 			data, err := io.ReadAll(rc)
 			if err != nil {
-				return nil, false, err
+				return nil, err
 			}
 
-			// Check if encrypted (has nonce prefix)
-			encrypted := len(data) > 12 // Minimal size for nonce + ciphertext
-			return data, encrypted, nil
+			return data, nil
 		}
 	}
 
-	return nil, false, fmt.Errorf("file %s not found in backup", filename)
+	return nil, fmt.Errorf("file %s not found in backup", filename)
 }
 
 // decrypt decrypts data using GCM

--- a/internal/sncli/backup.go
+++ b/internal/sncli/backup.go
@@ -486,8 +486,9 @@ type RestoreResult struct {
 	TagsCount  int
 }
 
-// GetBackupInfo reads backup metadata without restoring
-func GetBackupInfo(filename string, password string) (BackupManifest, error) {
+// GetBackupInfo reads backup metadata without restoring. No password is needed:
+// the manifest is stored in the clear.
+func GetBackupInfo(filename string) (BackupManifest, error) {
 	zipReader, err := zip.OpenReader(filename)
 	if err != nil {
 		return BackupManifest{}, fmt.Errorf("failed to open backup file: %w", err)

--- a/internal/sncli/backup_test.go
+++ b/internal/sncli/backup_test.go
@@ -1,0 +1,153 @@
+package sncli
+
+import (
+	"archive/zip"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeBackupArchive builds an archive the way BackupConfig.Run does, without
+// needing a session: manifest in the clear, payloads sealed when encrypting.
+func writeBackupArchive(t *testing.T, path, password string, encrypt bool) {
+	t.Helper()
+
+	b := &BackupConfig{OutputFile: path, Encrypt: encrypt, Password: password}
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+
+	manifest := BackupManifest{
+		ItemCounts: map[string]int{"notes": 0, "tags": 0},
+		Encrypted:  encrypt,
+		Version:    backupFormatVersion,
+	}
+
+	var gcm = func() (g interface {
+		Seal([]byte, []byte, []byte, []byte) []byte
+	}) {
+		return nil
+	}()
+	_ = gcm
+
+	if encrypt {
+		salt := make([]byte, backupSaltSize)
+		for i := range salt {
+			salt[i] = byte(i)
+		}
+
+		manifest.KDF = backupKDFName
+		manifest.Salt = base64.StdEncoding.EncodeToString(salt)
+		manifest.Iterations = backupKDFIterations
+
+		aead, err := newGCM(deriveBackupKey(password, salt, backupKDFIterations))
+		require.NoError(t, err)
+
+		for _, name := range []string{"notes.json", "tags.json"} {
+			require.NoError(t, b.writeZipFile(zw, name, []byte("[]"), aead))
+		}
+	} else {
+		for _, name := range []string{"notes.json", "tags.json"} {
+			require.NoError(t, b.writeZipFile(zw, name, []byte("[]"), nil))
+		}
+	}
+
+	manifestData, err := json.MarshalIndent(manifest, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, b.writeZipFile(zw, "manifest.json", manifestData, nil))
+	require.NoError(t, zw.Close())
+}
+
+// An encrypted backup must be restorable. Version 1.0 sealed the manifest as
+// well, so restore could never parse it and the archive was unrecoverable.
+func TestRestoreEncryptedBackupRoundTrip(t *testing.T) {
+	const password = "correct horse battery staple"
+
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	writeBackupArchive(t, path, password, true)
+
+	r := RestoreConfig{InputFile: path, Password: password, DryRun: true}
+
+	result, err := r.Run()
+	require.NoError(t, err)
+	require.True(t, result.Manifest.Encrypted)
+	require.Equal(t, backupFormatVersion, result.Manifest.Version)
+	require.Equal(t, backupKDFIterations, result.Manifest.Iterations)
+}
+
+func TestRestoreUnencryptedBackupRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	writeBackupArchive(t, path, "", false)
+
+	r := RestoreConfig{InputFile: path, DryRun: true}
+
+	result, err := r.Run()
+	require.NoError(t, err)
+	require.False(t, result.Manifest.Encrypted)
+}
+
+func TestRestoreEncryptedBackupWrongPassword(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	writeBackupArchive(t, path, "right-password", true)
+
+	r := RestoreConfig{InputFile: path, Password: "wrong-password", DryRun: true}
+
+	_, err := r.Run()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decrypt")
+}
+
+func TestRestoreEncryptedBackupRequiresPassword(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	writeBackupArchive(t, path, "hunter2", true)
+
+	r := RestoreConfig{InputFile: path, DryRun: true}
+
+	_, err := r.Run()
+	require.ErrorContains(t, err, "password required")
+}
+
+// Each backup must use its own salt, so one precomputed table cannot attack
+// every archive sn-cli has ever written.
+func TestBackupSaltsAreUnique(t *testing.T) {
+	const runs = 20
+
+	seen := make(map[string]bool, runs)
+
+	for range runs {
+		salt, err := newBackupSalt()
+		require.NoError(t, err)
+		require.Len(t, salt, backupSaltSize)
+
+		encoded := base64.StdEncoding.EncodeToString(salt)
+		require.False(t, seen[encoded], "salt repeated across backups")
+
+		seen[encoded] = true
+	}
+
+	require.Len(t, seen, runs)
+}
+
+// PBKDF2 work factor should meet current OWASP guidance.
+func TestBackupKDFParameters(t *testing.T) {
+	require.GreaterOrEqual(t, backupKDFIterations, 600000)
+	require.GreaterOrEqual(t, backupSaltSize, 16)
+}
+
+// GetBackupInfo must work on an encrypted backup: the manifest is not secret.
+func TestGetBackupInfoOnEncryptedBackup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	writeBackupArchive(t, path, "hunter2", true)
+
+	info, err := GetBackupInfo(path, "hunter2")
+	require.NoError(t, err)
+	require.True(t, info.Encrypted)
+	require.Equal(t, backupKDFName, info.KDF)
+}

--- a/internal/sncli/backup_test.go
+++ b/internal/sncli/backup_test.go
@@ -146,7 +146,7 @@ func TestGetBackupInfoOnEncryptedBackup(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "backup.zip")
 	writeBackupArchive(t, path, "hunter2", true)
 
-	info, err := GetBackupInfo(path, "hunter2")
+	info, err := GetBackupInfo(path)
 	require.NoError(t, err)
 	require.True(t, info.Encrypted)
 	require.Equal(t, backupKDFName, info.KDF)

--- a/internal/sncli/backup_test.go
+++ b/internal/sncli/backup_test.go
@@ -18,6 +18,7 @@ func writeBackupArchive(t *testing.T, path, password string, encrypt bool) {
 
 	b := &BackupConfig{OutputFile: path, Encrypt: encrypt, Password: password}
 
+	// #nosec G304 -- path is a file inside the test's own t.TempDir().
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	defer f.Close()

--- a/internal/sncli/main_test.go
+++ b/internal/sncli/main_test.go
@@ -129,12 +129,15 @@ func TestMain(m *testing.M) {
 	} else {
 		email := os.Getenv("SN_EMAIL")
 		password := os.Getenv("SN_PASSWORD")
-		if email == "" {
-			email = "gosn-v2-202509231858@lessknown.co.uk"
+
+		if email == "" || password == "" {
+			fmt.Fprintln(os.Stderr,
+				"SN_INTEGRATION_TESTS is set but SN_EMAIL and SN_PASSWORD are not: "+
+					"set both, or point SN_SERVER at a ramea instance")
+
+			os.Exit(1)
 		}
-		if password == "" {
-			password = "gosn-v2-202509231858@lessknown.co.uk"
-		}
+
 		signIn(SNServerURL, email, password)
 	}
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,10 @@ sonar.organization=jonhadfield
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Test coverage. Produced by the "Run tests" step in .github/workflows/sonarqube.yml.
+sonar.go.coverage.reportPaths=cover.out
+
+# Keep generated and vendored code out of the analysis.
+sonar.exclusions=**/vendor/**,**/*.pb.go
+sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
SonarCloud reported **6 vulnerabilities**, giving the project a security rating of **D**. Four of them were real defects in backup encryption, and chasing them down turned up a data-loss bug.

## Encrypted backups could never be restored

`BackupConfig.Run` sealed `manifest.json` along with everything else, but the restore path `json.Unmarshal`s the manifest **without decrypting it**. So restoring any encrypted backup failed with:

```
failed to parse manifest: invalid character '\xf4' looking for beginning of value
```

Every archive ever written by `sn backup --encrypt` is unreadable by `sn restore`. Confirmed by building an archive in exactly the format `Run` produces and restoring it.

The manifest holds no secrets (timestamp, item counts, flags) and has to be readable *before* the key exists, so it is now always written in the clear and carries the key-derivation parameters.

## The two crypto weaknesses

Because no encrypted backup was ever restorable, there is **no compatibility cost** to changing the key derivation:

| | before | after |
|---|---|---|
| salt | `"sn-cli-backup-salt"`, constant for every backup of every user | 32 random bytes per backup, recorded in the manifest |
| PBKDF2 iterations | 100,000 | 600,000 (current OWASP guidance for HMAC-SHA256) |

A single shared salt means one precomputed table attacks every sn-cli backup in existence, which is what `go:S2053` flags.

Manifest version is now `2.0`. Restore reads the salt and iteration count from the manifest. A `1.0` encrypted archive now produces an error explaining what happened rather than a stray byte of ciphertext. Unencrypted `1.0` backups restore exactly as before.

## Other findings

- `readZipFile` decided a member was encrypted with `len(data) > 12`, true of essentially any file. Encryption is now read from the manifest.
- Pinned the two third-party actions to full commit SHAs (`githubactions:S7637`).
- Coverage was reporting **0%** because the scan workflow never ran the tests. It now runs them and passes `cover.out` to SonarCloud.

## Tests

New round-trip coverage for encrypted and unencrypted restore, wrong password, missing password, salt uniqueness, and `GetBackupInfo` on an encrypted archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKSZwABnkoJTMcpUhFife3
